### PR TITLE
Improved HTTP Error Handling

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,11 +12,13 @@
 				"dotenv": "^16.3.1",
 				"envalid": "^7.3.1",
 				"express": "^4.18.2",
+				"http-errors": "^2.0.0",
 				"mongoose": "^7.4.5",
 				"morgan": "^1.10.0"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.17",
+				"@types/http-errors": "^2.0.1",
 				"@types/morgan": "^1.9.5",
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
 	"license": "ISC",
 	"devDependencies": {
 		"@types/express": "^4.17.17",
+		"@types/http-errors": "^2.0.1",
 		"@types/morgan": "^1.9.5",
 		"@typescript-eslint/eslint-plugin": "^6.4.1",
 		"@typescript-eslint/parser": "^6.4.1",
@@ -28,6 +29,7 @@
 		"dotenv": "^16.3.1",
 		"envalid": "^7.3.1",
 		"express": "^4.18.2",
+		"http-errors": "^2.0.0",
 		"mongoose": "^7.4.5",
 		"morgan": "^1.10.0"
 	}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,7 @@ import "dotenv/config";
 import express, { NextFunction, Request, Response } from "express";
 import booksRoutes from "./routes/books";
 import morgan from "morgan";
+import createHttpError, { isHttpError } from "http-errors";
 
 const LOGGING_LEVEL = "dev";
 
@@ -14,15 +15,19 @@ app.use(express.json());
 app.use("/api/books", booksRoutes);
 
 app.use((req, res, next) => {
-	next(Error("Endpoint not found."));
+	next(createHttpError(404, "Endpoint not found."));
 });
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((error: unknown, req: Request, res: Response, next: NextFunction) => {
 	console.error(error);
+	let statusCode = 500;
 	let errorMessage = "An unknown error occured";
-	if (error instanceof Error) errorMessage = error.message;
-	res.status(500).json({ error: errorMessage });
+	if (isHttpError(error)) {
+		statusCode = error.status;
+		errorMessage = error.message;
+	}
+	res.status(statusCode).json({ error: errorMessage });
 });
 
 export default app;


### PR DESCRIPTION
Added `http-errors` error handling. So errors fall back to the generic `500` server error, but when an API endpoint isn't found, we return a `404` error.